### PR TITLE
Implemented schema import feature.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,14 @@ pull_request_rules:
       add:
       - model
       remove: []
+- name: Label schema-util PRs
+  conditions:
+  - files~=^modules/schema-util/
+  actions:
+    label:
+      add:
+      - schema-util
+      remove: []
 - name: Label server PRs
   conditions:
   - files~=^modules/

--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val engage_web_server = project
   )
   .dependsOn(engage_server)
   .dependsOn(engage_model.jvm % "compile->compile;test->test")
+  .dependsOn(schema_util)
 
 lazy val engage_model = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
@@ -146,6 +147,17 @@ lazy val engage_model = crossProject(JVMPlatform, JSPlatform)
     // And add a custom one
     libraryDependencies += JavaTimeJS.value,
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
+
+lazy val schema_util = project
+  .in(file("modules/schema-util"))
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      CatsEffect.value,
+      Fs2,
+      Log4Cats.value
+    ) ++ MUnit.value ++ LucumaCore.value ++ Http4sClient ++ Grackle.value
   )
 
 lazy val engage_server = project

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/SchemaStitcher.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/SchemaStitcher.scala
@@ -1,0 +1,177 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.schema.util
+
+import cats.data.{Ior, NonEmptySet}
+import cats.effect.Sync
+import cats.kernel.Order
+import cats.parse.Parser.*
+import cats.parse.Rfc5234.{alpha, digit, wsp}
+import cats.parse.{Parser, Parser0}
+import cats.syntax.all.*
+import cats.{Applicative, Eq, Monad}
+import edu.gemini.grackle.*
+import eu.timepit.refined.types.string.NonEmptyString
+
+import scala.io.Source
+import scala.tools.nsc.io.Path
+
+// SchemaStitcher can build a grackle Schema from schema files that contains import statements of the form:
+// #import <type list> from <schema file name>
+// <type list> is a coma separated list of the times to import, or * to import all of them
+trait SchemaStitcher[F[_]] {
+  def build: F[Result[Schema]]
+}
+
+object SchemaStitcher {
+
+  private case class SchemaStitcherImpl[F[_]: Sync](
+    root:     Path,
+    resolver: SourceResolver[F]
+  ) extends SchemaStitcher[F] {
+
+    // Process to build the schema:
+    // 1. Build a schema dependency tree starting with the root schema.
+    // 2. Recursively collapse the tree into a List, with dependencies first
+    // 3. Merge all elements referencing the same schema. Only the left-most one is left, and its type list is replaced
+    //    by the union of all the others
+    // 4. Build the final schema text joining the string representation of each schema. Only the used type are put in
+    //    the string.
+    // 5. Build the Schema instance
+    override def build: F[Result[Schema]] = dependenciesTree(List.empty, root)
+      .map(x => collapseToList(AllElements, x))
+      .map(x => merge(x, List.empty))
+      .map(_.map(_.asString).mkString("\n"))
+      .map(Schema.apply(_))
+
+    def dependenciesTree(pathToRoot: List[Path], schemaName: Path): F[DependencyNode] =
+      if (pathToRoot.contains(schemaName)) {
+        Sync[F].raiseError(
+          new Exception(s"Found circular reference when resolving schema $schemaName")
+        )
+      } else {
+        resolver.resolve(schemaName).map(_.getLines.toList).use { ll =>
+          ll.map(importLineParser.parse)
+            .collect { case Right((_, (els, path))) =>
+              dependenciesTree(pathToRoot :+ schemaName, path).map((els, _))
+            }
+            .sequence
+            .map(u => DependencyNode(schemaName, ll, u))
+        }
+      }
+
+    def collapseToList(els: Elements, node: DependencyNode): List[SchemaNode] =
+      node.dependencies.flatMap { case (s, n) => collapseToList(s, n) } :+ SchemaNode(
+        node.v,
+        node.src.mkString("\n"),
+        els
+      )
+
+    def merge(l: List[SchemaNode], acc: List[SchemaNode]): List[SchemaNode] =
+      l match {
+        case Nil      => acc
+        case x :: Nil => acc :+ x
+        case x :: xx  =>
+          val (m, r) = xx.partition(_.name === x.name)
+          val s      = m.fold(x)((a, b) => SchemaNode(a.name, a.src, a.elements.union(b.elements)))
+          merge(r, acc :+ s)
+      }
+  }
+
+  sealed trait Elements
+  case object AllElements                                      extends Elements
+  final case class ElementList(l: NonEmptySet[NonEmptyString]) extends Elements
+
+  extension (el: Elements) {
+    def union(other: Elements): Elements = (el, other) match {
+      case (ElementList(l1), ElementList(l2)) => ElementList(l1 ++ l2)
+      case _                                  => AllElements
+    }
+  }
+
+  case class DependencyNode(
+    v:            Path,
+    src:          List[String],
+    dependencies: List[(Elements, DependencyNode)]
+  )
+
+  case class SchemaNode(name: Path, src: String, elements: Elements) {
+    def asString: String = elements match {
+      case AllElements    => src
+      case ElementList(l) => asString(l)
+    }
+
+    def asString(l: NonEmptySet[NonEmptyString]): String =
+      Schema(src) match {
+        case Ior.Right(b)   =>
+          resolveTypes(b.types,
+                       l.toList.map(x => b.types.find(_.name === x.toString)).flattenOption,
+                       List.empty
+          )
+            .map(SchemaRenderer.renderTypeDefn)
+            .mkString("\n")
+        case Ior.Both(_, b) =>
+          resolveTypes(b.types,
+                       l.toList.map(x => b.types.find(_.name === x.toString)).flattenOption,
+                       List.empty
+          )
+            .map(SchemaRenderer.renderTypeDefn)
+            .mkString("\n")
+        case _              => ""
+      }
+
+    def resolveTypes(
+      types:    List[NamedType],
+      newNames: List[NamedType],
+      acc:      List[NamedType]
+    ): List[NamedType] =
+      if (newNames.isEmpty) {
+        acc
+      } else {
+        val uniqueNews = newNames.distinct
+        val nextVals   = uniqueNews
+          .flatMap {
+            case fields: TypeWithFields                => fields.fields.map(_.tpe.underlying.asNamed).flattenOption
+            case UnionType(name, description, members) => members
+            case _                                     => List.empty
+          }
+          .map(_.dealias)
+          .filter {
+            case u: ScalarType => !u.isBuiltIn
+            case v             => !acc.contains(v) && !uniqueNews.contains(v)
+          }
+        resolveTypes(types, nextVals, uniqueNews ++ acc)
+      }
+  }
+
+  given Order[NonEmptyString] = Order.by(_.toString)
+
+  val allElementsParser: Parser[Elements]                        = char('*').as(AllElements)
+  val firstCharInTypeParser: Parser[Char]                        = alpha | charIn('_')
+  val otherCharsInTypeParser: Parser[Char]                       = firstCharInTypeParser | digit
+  val elementNameParser: Parser[NonEmptyString]                  =
+    (firstCharInTypeParser ~ otherCharsInTypeParser.rep0).map { case (x, xx) =>
+      NonEmptyString.unsafeFrom((x +: xx).mkString(""))
+    }
+  val elementNameListParser: Parser[NonEmptySet[NonEmptyString]] =
+    (elementNameParser ~ (wsp.rep0.with1 *> char(
+      ','
+    ) *> wsp.rep0 *> elementNameParser).backtrack.rep0)
+      .map { case (x, xx) => NonEmptySet.of(x, xx: _*) }
+  val elementListParser: Parser[Elements]                        = elementNameListParser.map(ElementList.apply)
+  val filenameCharParser: Parser[Char]                           = digit | alpha | charIn('.', '_', '\\')
+  val schemaFilenameParser: Parser[Path]                         =
+    (Parser.char('\"') *> filenameCharParser.rep <* Parser.char('\"')).map(x =>
+      Path.apply(x.toList.mkString(""))
+    )
+  val importLineParser: Parser[(Elements, Path)]                 = (wsp.rep0.with1 *> string(
+    "#import"
+  ) *> wsp.rep *> (allElementsParser | elementListParser) <* wsp.rep)
+    ~ (string("from") *> wsp.rep *> schemaFilenameParser)
+
+  // The only way to build a SchemaStitcher
+  def apply[F[_]: Sync](root: Path, resolver: SourceResolver[F]): SchemaStitcher[F] =
+    SchemaStitcherImpl(root, resolver)
+
+}

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
@@ -4,7 +4,7 @@
 package edu.gemini.schema.util
 
 import scala.io.Source
-import scala.tools.nsc.io.Path
+import java.nio.file.Path
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.effect.syntax.all.*

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/SourceResolver.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.schema.util
+
+import scala.io.Source
+import scala.tools.nsc.io.Path
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
+import cats.ApplicativeThrow
+
+// Trait used to find the schema file
+trait SourceResolver[F[_]] {
+  def resolve(name: Path): Resource[F, Source]
+}
+
+object SourceResolver {
+
+  def fromResource[F[_]: Sync](classLoader: ClassLoader): SourceResolver[F] = (name: Path) =>
+    Resource.make(Sync[F].delay(Source.fromResource(name.toString, classLoader)))(x =>
+      Sync[F].delay(x.close)
+    )
+
+  def fromString[F[_]: Sync](name: Path, content: String): SourceResolver[F] = (n: Path) =>
+    if (n === name) Resource.pure(Source.fromString(content))
+    else Resource.raiseError[F, Source, Throwable](new Error(s"Unknown source $n"))
+
+  def fromStringMap[F[_]: Sync](m: Map[Path, String]): SourceResolver[F] = (name: Path) =>
+    m.get(name)
+      .map(x => Resource.pure(Source.fromString(x)))
+      .getOrElse(Resource.raiseError[F, Source, Throwable](new Error(s"Unknown source $name")))
+
+  extension [F[_]: ApplicativeThrow](s: SourceResolver[F])
+    def or(other: SourceResolver[F]): SourceResolver[F] = (name: Path) =>
+      s.resolve(name).handleErrorWith[Source, Throwable](_ => other.resolve(name))
+
+}

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.schema
+
+import cats.Eq
+
+import scala.tools.nsc.io.Path
+
+package object util {
+  given pathEq: Eq[Path] = Eq.fromUniversalEquals
+}

--- a/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
+++ b/modules/schema-util/src/main/scala/edu/gemini/schema/util/package.scala
@@ -5,7 +5,7 @@ package edu.gemini.schema
 
 import cats.Eq
 
-import scala.tools.nsc.io.Path
+import java.nio.file.Path
 
 package object util {
   given pathEq: Eq[Path] = Eq.fromUniversalEquals

--- a/modules/schema-util/src/test/scala/edu/gemini/schema/util/SchemaStitcherTest.scala
+++ b/modules/schema-util/src/test/scala/edu/gemini/schema/util/SchemaStitcherTest.scala
@@ -1,0 +1,121 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.schema.util
+
+import cats.Eq
+import cats.data.Ior
+import cats.effect.{IO, Resource}
+import cats.syntax.all.*
+import edu.gemini.grackle.{Result, Schema}
+import junit.framework.TestCase
+import munit.Assertions.*
+import munit.CatsEffectSuite
+
+import scala.io.Source
+import scala.tools.nsc.io.Path
+
+class SchemaStitcherTest extends CatsEffectSuite {
+  import SchemaStitcherTest.*
+
+  test("SchemaStitcher should parse import statements") {
+    schemaResolver.resolve("baseSchema.graphql").map { x =>
+      val a = x.getLines.toList.map(SchemaStitcher.importLineParser.parse).collect {
+        case Right((_, (els, path))) => (els, path)
+      }
+
+      assertEquals(a.length, 2)
+      a(0) match {
+        case (SchemaStitcher.AllElements, path) => assertEquals(path.path, "schema1.graphql")
+        case _                                  => fail
+      }
+      a(1) match {
+        case (SchemaStitcher.ElementList(List("TypeA")), path) =>
+          assertEquals(path.path, "schema2.graphql")
+        case _                                                 => fail
+      }
+    }
+  }
+
+  test("SchemaStitcher should compose schema") {
+    SchemaStitcher[IO]("baseSchema.graphql", schemaResolver).build.map { x =>
+      (x, expectedSchema) match {
+        case (Ior.Right(a), Ior.Right(b)) => assertEquals(a.toString, b.toString)
+        case _                            => fail("Error creating schema")
+      }
+    }
+  }
+
+}
+
+object SchemaStitcherTest {
+
+  val schema1: String = """
+    |#import TypeA from "schema2.graphql"
+    |
+    |type TypeB {
+    |  val1: TypeA!
+    |}
+  """.stripMargin
+
+  val schema2: String = """
+    |enum EnumX {
+    |  VAL0
+    |  VAL1
+    |}
+    |
+    |type TypeA {
+    |  attr0: [EnumX]!
+    |}
+    |
+    |type TypeB {
+    |  attr0: Boolean!
+    |  attr1: Float
+    |}
+  """.stripMargin
+
+  val baseSchema: String = """
+    |#import * from "schema1.graphql"
+    |#import TypeA from "schema2.graphql"
+    |
+    |type TypeC {
+    |  attr0: TypeB
+    |}
+    |
+    |type Query {
+    |  query1(par: TypeA!): TypeC!
+    |}
+  """.stripMargin
+
+  val expectedSchema: Result[Schema] = Schema("""
+    |enum EnumX {
+    |  VAL0
+    |  VAL1
+    |}
+    |
+    |type TypeA {
+    |  attr0: [EnumX]!
+    |}
+    |
+    |type TypeB {
+    |  val1: TypeA!
+    |}
+    |
+    |type TypeC {
+    |  attr0: TypeB
+    |}
+    |
+    |type Query {
+    |  query1(par: TypeA!): TypeC!
+    |}
+    |""".stripMargin)
+
+  val schemaResolver: SourceResolver[IO] = SourceResolver.fromStringMap(
+    Map(
+      Path("baseSchema.graphql") -> baseSchema,
+      Path("schema1.graphql")    -> schema1,
+      Path("schema2.graphql")    -> schema2
+    )
+  )
+
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -73,7 +73,7 @@ object Settings {
     val gmpStatusDatabase   = "0.3.7"
     val gmpCmdClientBridge  = "0.6.7"
     val guava               = "31.0.1-jre"
-    val prometheusClient    = "0.14.1"
+    val prometheusClient    = "0.16.0"
     val geminiLocales       = "0.7.0"
     val pprint              = "0.8.1"
     val jaxb                = "3.0.1"
@@ -88,15 +88,15 @@ object Settings {
     val gppUI   = "0.0.3"
 
     // Lucuma
-    val lucumaCore    = "0.62.0"
-    val lucumaUI      = "0.60.1"
-    val lucumaSchemas = "0.38.4"
+    val lucumaCore    = "0.64.0"
+    val lucumaUI      = "0.66.0"
+    val lucumaSchemas = "0.42.1"
 
     val grackle = "0.10.3"
 
     val graphQLRoutes = "0.5.10"
 
-    val clue = "0.23.1"
+    val clue = "0.24.1"
 
     val sttp = "3.8.9"
 


### PR DESCRIPTION
This update implements the ability to build a grackle Schema from schema files that import types from other schemas.
The code finds all the dependencies, extract the definition of the imported types, and build one single schema.